### PR TITLE
use provided keys in get_meshs

### DIFF
--- a/jaxpower/mock.py
+++ b/jaxpower/mock.py
@@ -135,13 +135,13 @@ def generate_anisotropic_gaussian_mesh(mattrs: MeshAttrs, poles: ObservableTree 
                     return get_theory(pole=pole).reshape(kshape)
 
             # The mesh for ell = 0
-            normal = generate_normal(key[0])
+            normal = generate_normal(keys[0])
             mesh = (normal * _interp(l00)).c2r()
             del l00
             mesh2 = normal * _interp(l10)
             del normal
             # The mesh for ell = 2
-            mesh2 += generate_normal(key[1]) * _interp(jnp.sqrt(a11 - l10**2))
+            mesh2 += generate_normal(keys[1]) * _interp(jnp.sqrt(a11 - l10**2))
             del a11, l10
             return mesh, mesh2
 


### PR DESCRIPTION
Fixes a typo in  e9103f0 that reused a single, global key in the `get_mesh(keys)` functions instead of the `keys` argument